### PR TITLE
The parenvs now in the pryr package.

### DIFF
--- a/environments.rmd
+++ b/environments.rmd
@@ -35,7 +35,7 @@ R uses a similar system to save R objects. Each object is saved inside of an env
 You can see R's environment system with the `parenvs` function in the devtools package. `parenvs(all = TRUE)` will return a list of the environments that your R session is using. The actual output will vary from session to session depending on which packages you have loaded. Here's the output from my current session:
 
 ```r
-library(devtools)
+library(pryr)
 parenvs(all = TRUE)
 ##    label                            name               
 ## 1  <environment: R_GlobalEnv>       ""                 


### PR DESCRIPTION
https://github.com/r-lib/devtools/blob/master/NEWS.md  

> The `parenvs()` function has been removed from `devtools`, because is now in the `pryr` package.