### PR TITLE
feature: make all solution chunks foldable and folded by default

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -8,4 +8,6 @@ bookdown::gitbook:
       link: https://github.com/rstudio-education/hopr/edit/master/%s
       text: "Edit"
     sharing: no
+  includes:
+    after_body: fold_solutions.html
   css: hopr.css

--- a/fold_solutions.html
+++ b/fold_solutions.html
@@ -1,0 +1,16 @@
+<script type="text/javascript">
+  var codes = document.querySelectorAll('div.solution');
+  var code, i, d, s, p;
+  for (i = 0; i < codes.length; i++) {
+    code = codes[i];
+    p = code.parentNode;
+    d = document.createElement('details');
+    s = document.createElement('summary');
+    s.innerText = 'Show/Hide Solution';
+    // <details><summary>Details</summary></details>
+    d.appendChild(s);
+    // move the code into <details>
+    p.replaceChild(d, code);
+    d.appendChild(code);
+  }
+</script>


### PR DESCRIPTION
I used this book to give an intro into R course, and it was very useful to teach both people without any prior programming or R experience, and those that have already worked a bit in R. It enabled self-paced studying, with help among participants and by the instructor. So thanks a lot for this resource!

That said, one major feedback I got, was that it was annoying to always already see the solutions to the exercises. It apparently prevented people from sitting down and thinking the exercise through, before evaluating whether they got it right. As I might want to come back to using this book and as others will probably have a similar problem, I spent the past week looking around for a way to get all ```{solution} code chunks foldable and folded by default. And here it is:

One can [wrap all the respective code chunks in `<details></details>` `html` tags](https://stackoverflow.com/a/53870441). To automated this across all documents, I use the [suggestion for such `<details>` elements from the RMarkdown cookbook](https://bookdown.org/yihui/rmarkdown-cookbook/details-tag.html), and get the respective code snippet to be appended to every document in the book by using the [`html_document` `includes:` tag `after_body:`](https://bookdown.org/yihui/rmarkdown/html-document.html#includes). This works, when compiling the book locally with `Rscript -e 'bookdown::render_book("index.rmd")'` with `knitr_1.42` and `bookdown_0.32`.

A more thorough solution would probably change the `solution` chunk engine in `bookdown` to include a configuration option for the [generic code folding functionality in `RMarkdown` `html_document` rendering](https://bookdown.org/yihui/rmarkdown/html-document.html#code-folding). But I couldn't figure out the respective Lua code. And this solution here works, with minimal changes.