### PR TITLE
update objects.rmd Data Frame section: new default `stringsAsFactors = FALSE`

### DIFF
--- a/objects.rmd
+++ b/objects.rmd
@@ -763,18 +763,22 @@ class(df)
 
 str(df)
 ## 'data.frame':	3 obs. of  3 variables:
-##  $ face : Factor w/ 3 levels "ace","six","two": 1 3 2
-##  $ suit : Factor w/ 1 level "clubs": 1 1 1
+##  $ face : chr  "ace" "two" "six"
+##  $ suit : chr  "clubs" "clubs" "clubs"
 ##  $ value: num  1 2 3
 ```
 
-Notice that R saved your character strings as factors. I told you that R likes factors! It is not a very big deal here, but you can prevent this behavior by adding the argument `stringsAsFactors = FALSE` to `data.frame`:
+Note how R saved your character strings - as character strings! This is the default. Since, however, having variables saved as factors can be appropriate and useful in many contexts, be aware that you can update this behavior by adding the argument `stringsAsFactors = TRUE` to `data.frame`:
 
 ```r
 df <- data.frame(face = c("ace", "two", "six"),  
   suit = c("clubs", "clubs", "clubs"), value = c(1, 2, 3),
-  stringsAsFactors = FALSE)
+  stringsAsFactors = TRUE)
 ```
+
+The default had previously been `stringsAsFactors = TRUE`, but has been changed 
+to `FALSE`. was See [here](https://blog.r-project.org/2020/02/16/stringsasfactors/) 
+for a thoughtful discussion of the history of this default and its reproducibility implications. 
 
 A data frame is a great way to build an entire deck of cards. You can make each row in the data frame a playing card, and each column a type of value—each with its own appropriate data type. The data frame would look something like this:
 


### PR DESCRIPTION
I've committed changes to address issue #79 regarding the default `stringsAsFactors` behavior for `data.frame`.

779 - 781 Further, I briefly discuss and link to an R-Project blog, as there is some nuance of educational value for curious readers who click through.  It is an R Project resource so I figured might be fair game for inclusion, but it does read a little clunky transitioning into line 783 so could well be removed entirely.  

In any case, I'm happy to follow up with any suggested changes to this until there is an update that can be merged to community-facing inclusion in this terrific resource. 

Thank you!!